### PR TITLE
[FIX] collect correct proj_error summary

### DIFF
--- a/SfMLearner.py
+++ b/SfMLearner.py
@@ -188,7 +188,7 @@ class SfMLearner(object):
                 tf.summary.image('scale%d_projected_image_%d' % (s, i), 
                     self.deprocess_image(self.proj_image_stack_all[s][:, :, :, i*3:(i+1)*3]))
                 tf.summary.image('scale%d_proj_error_%d' % (s, i),
-                    tf.expand_dims(self.proj_error_stack_all[s][:,:,:,i], -1))
+                    self.deprocess_image(tf.clip_by_value(self.proj_error_stack_all[s][:,:,:,i*3:(i+1)*3] - 1, -1, 1)))
         tf.summary.histogram("tx", self.pred_poses[:,:,0])
         tf.summary.histogram("ty", self.pred_poses[:,:,1])
         tf.summary.histogram("tz", self.pred_poses[:,:,2])


### PR DESCRIPTION
Initial code was assuming 1 dimension photometric error while there's actually 3. As a consequence, `self.proj_error_stack_all[s][:, :, :, 1]` does not give you the second photoemtric error map, but Green layer of the first photometric error map.

Some additionnal deprocessing has been added to make a 0 error black (i.e. equal to -1) and a 1 error white (while the max error is 2) for contrast purpose.