### PR TITLE
Fix for unknown command line flags issue

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,6 +22,8 @@ flags.DEFINE_integer("max_steps", 200000, "Maximum number of training iterations
 flags.DEFINE_integer("summary_freq", 100, "Logging every log_freq iterations")
 flags.DEFINE_integer("save_latest_freq", 5000, \
     "Save the latest model every save_latest_freq iterations (overwrites the previous latest model)")
+flags.DEFINE_integer("num_source", 2, "Number of source images")
+flags.DEFINE_integer("num_scales", 4, "Number of scaling points")
 flags.DEFINE_boolean("continue_train", False, "Continue training from previous checkpoint")
 FLAGS = flags.FLAGS
 


### PR DESCRIPTION
Fix for missing flags, for example:
"absl.flags._exceptions.UnrecognizedFlagError: Unknown command line flag 'num_source'"